### PR TITLE
Update lesson examples to use res.json()

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,5 @@
 const express = require("express");
 const logger = require("morgan");
-// const favicon = require('serve-favicon')
 
 const app = express();
 
@@ -16,32 +15,34 @@ app.use(express.static("public"));
 // Example - Query Strings (?)
 app.get('/search', (req, res) => {
   console.log(req.query);
-  res.send(req.query);
+  res.json(req.query);
 });
-
 
 
 // Example - Route Parameters (:)
 app.get("/accounts/:username", (req, res) => {
   console.log(req.params);
-  res.send(req.params);
+  res.json(req.params);
 });
 
 
 app.get("/users/:username/books/:bookId", (req, res, next) => {
   console.log("req.params -> ", req.params);
 
-  res.send(req.params);
+  res.json(req.params);
 });
+
 
 app.get("/results", (req, res, next) => {
   console.log("req.query -> ", req.query);
 
-  res.send(req.query);
+  res.json(req.query);
 });
+
 
 app.get("/", (req, res, next) => {
   res.sendFile(__dirname + "/views/index.html");
 });
+
 
 app.listen(3000, () => console.log("App listening on port 3000!"));


### PR DESCRIPTION
This PR updates the lesson example code to use `res.json()` instead of the `res.send()` method for sending JSON responses. The changes include:

- Replacing all instances of calling `res.send()` method with `res.json()`.
- Updating the lesson code example to reflect the changes in the lesson.